### PR TITLE
updated version to 4.4.1 in xml and readme to reflect the bug fix

### DIFF
--- a/Custom Device Source/Custom Device Scan Engine.xml
+++ b/Custom Device Source/Custom Device Scan Engine.xml
@@ -5,7 +5,7 @@
     <eng>National Instruments::Scan Engine and EtherCAT</eng>
     <loc>National Instruments::Scan Engine and EtherCAT</loc>
   </AddMenu>
-  <Version>4.4.0</Version>
+  <Version>4.4.1</Version>
   <Type>Inline HW Interface</Type>
   <MaxOccurrence>1</MaxOccurrence>
   <MainPageGUID>A04A67D4-9B64-052B-A031-6B05377B9B10</MainPageGUID>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Scan Engine Custom Device ##
 
-**Scan Engine Custom Device**  allows users to easily read scanned I/O from C series modules located in a CompactRIO or NI 914x EtherCAT chassis.  The add-on also supports custom FPGA personalities to be used with a 914x chassis. From version 4.3, there is support for generic EtherCAT slaves (PDO only). From version 4.4, there is support for NI Remote I/O modules as well.
+**Scan Engine Custom Device**  allows users to easily read scanned I/O from C series modules located in a CompactRIO or NI 914x EtherCAT chassis.  The add-on also supports custom FPGA personalities to be used with a 914x chassis. From version 4.3, there is support for generic EtherCAT slaves (PDO only). From version 4.4.1, there is support for NI Remote I/O modules as well.
 
 ### LabVIEW Version ###
 


### PR DESCRIPTION
I figured we should update the versioning prior to posting it on the community (4.4.0 to 4.4.1) so we can tell if customers have the version that remote i/o will not work in